### PR TITLE
Add single quotes around find command regex

### DIFF
--- a/xcode-helpers.el
+++ b/xcode-helpers.el
@@ -59,7 +59,7 @@
 (defun xcode-find-binaries ()
 	(mapcar #'string-trim
 					(split-string
-					 (shell-command-to-string "find ~/Library/Developer/Xcode/DerivedData/ -name *.app"))))
+					 (shell-command-to-string "find ~/Library/Developer/Xcode/DerivedData/ -name '*.app'"))))
 
 (defun xcode-find-storyboards-for-directory (directory)
   (mapcar #'string-trim


### PR DESCRIPTION
Example results from the two commands (with or without single quotes).

$ ~/Library/Developer/Xcode/DerivedData find . -name '*.app'
./adfadf-dhpowlldubsdxfevmnigprxnzqjz/Build/Products/Debug-iphonesimulator/adfadf.app
./AdjustTest-cpsvgltfoqqazraskzjxxvbagxzc/Build/Products/Debug-iphoneos/AdjustTest.app
./asdfdasf-asvfiodovxtybacuguxpysxlynby/Build/Products/Debug-iphonesimulator/asdfdasf.app
./planit-fmcbyrhltmevkddvtdwezlmfvxal/Build/Products/Debug-iphonesimulator/planit.app
./pushapnstest-dzitxbzfhucqugdkbaxuloijkkny/Build/Products/Debug-iphoneos/pushapnstest.app
./PushTest-bnkgovrgmgacwkedoluazzstychs/Build/Products/Debug-iphoneos/PushTest.app
./Rotolling-ddtfqhxqtziinicqjihyqkvickwt/Build/Products/Debug-iphonesimulator/Rotolling.app
./TSApp-cprgeffiocctdafxumndaupomkmk/Build/Products/Debug-iphoneos/TSApp.app
./testdeletewhenever-gnyyimcjotzpcbggrkvkvpmxbkmx/Build/Products/Debug-iphonesimulator/testdeletewhenever.app
./testingContacts-blxrxafqkmavnfdwlibcnzqrdmvo/Build/Products/Debug-iphoneos/testingContacts.app
./TextKitDemo-dnqypqjcxjcsolbgmubbxqdymsbh/Build/Products/Debug-iphonesimulator/TextKitDemo.app
./W-ecktsqbupbqouwemfpivmmgnaoft/Build/Products/Debug-iphoneos/W.app
./W-ecktsqbupbqouwemfpivmmgnaoft/Build/Products/Debug-iphonesimulator/W.app
./W-faiocjbbymhdkyailfgkzrkpfiuc/Build/Products/Debug-iphoneos/W.app
./W-faiocjbbymhdkyailfgkzrkpfiuc/Build/Products/Debug-iphonesimulator/W.app
$ ~/Library/Developer/Xcode/DerivedData find . -name *.app
zsh: no matches found: *.app
$ ~/Library/Developer/Xcode/DerivedData
