### PR TITLE
Run xcode commands in project root when possible

### DIFF
--- a/xcode-helpers.el
+++ b/xcode-helpers.el
@@ -159,7 +159,7 @@
 If projectile available, use projectile.
 Else, use locate-dominating-file.
 Finally fall back to the current directory."
-  (if (not (fboundp 'projectile-project-root))
+  (if (fboundp 'projectile-project-root)
       (projectile-project-root)
     (or (locate-dominating-file default-directory ".xctool-args")
         default-directory)))

--- a/xcode-helpers.el
+++ b/xcode-helpers.el
@@ -142,9 +142,26 @@
   (xcode-completing-read "Select build config:" '("Debug" "Release") nil t))
 
 (defun xcode-compile (command)
-  (compile command))
+  (xcode-in-root
+   (compile command)))
 
 (defun xcode-use-xctool ()
 	(setq xcode-xctool-path "/usr/local/bin/xctool"))
+
+(defmacro xcode-in-root (body)
+  "Execute BODY form with `xcode-project-directory' as
+``default-directory''."
+  `(let ((default-directory (xcode-project-directory)))
+     ,body))
+
+(defun xcode-project-directory ()
+  "Get project directory.
+If projectile available, use projectile.
+Else, use locate-dominating-file.
+Finally fall back to the current directory."
+  (if (not (fboundp 'projectile-project-root))
+      (projectile-project-root)
+    (or (locate-dominating-file default-directory ".xctool-args")
+        default-directory)))
 
 (provide 'xcode-helpers)

--- a/xcode-running.el
+++ b/xcode-running.el
@@ -19,25 +19,30 @@
 (require 'xcode-helpers)
 
 (defun xcode-xctool-run ()
-	"Runs the Xcode project in sim using xctool."
+  "Runs the Xcode project in sim using xctool."
   (interactive)
-	(compile
-	 (format "ios-sim launch %s --devicetypeid '%s'"
-					 (xcode-completing-read
-						"Select app: "
-						(xcode-find-binaries) nil t)
-					 xcode-ios-sim-devicetype)))
+  (xcode-in-root (compile
+                  (format "ios-sim launch %s --devicetypeid '%s'"
+                          (xcode-completing-read
+                           "Select app: "
+                           (xcode-find-binaries) nil t)
+                          xcode-ios-sim-devicetype))))
 
 (defun xcode-xctool-build-and-run ()
-	"Build and run the in sim using xctool"
-	(interactive)
-	(message "Building...")
-	(shell-command-to-string "xctool build")
-	(compile
-	 (format "ios-sim launch %s --devicetypeid '%s'"
-					 (xcode-completing-read
-						"Select app: "
-						(xcode-find-binaries) nil t)
-					 xcode-ios-sim-devicetype)))
+  "Build and run the in sim using xctool"
+  (interactive)
+  (message "Building...")
+  (add-hook 'compilation-finish-functions 'xcode-on-build-finish)
+  (xcode-compile "xctool build"))
+
+(defun xcode-on-build-finish (buffer desc)
+  "Callback function after compilation finishes."
+  (xcode-in-root (compile
+                  (format "ios-sim launch %s --devicetypeid '%s'"
+                          (xcode-completing-read
+                           "Select app: "
+                           (xcode-find-binaries) nil t)
+                          xcode-ios-sim-devicetype)))
+  (remove-hook 'compilation-finish-functions 'xcode-on-build-finish))
 
 (provide 'xcode-running)


### PR DESCRIPTION
- Wrap 'compile in a macro that sets the default-directory to  the project directory.
- Changed shell-command-to-string in xcode-running to use compile.
- Changed xcode-xctool-build-and-run functionality to display available
  binaries after compilation finishes.

Hope the changes in xcode-running weren't too intrusive.
