### PR TITLE
Skip user input if only one option to select

### DIFF
--- a/xcode-mode.el
+++ b/xcode-mode.el
@@ -161,14 +161,8 @@
 
 (defun xcode-on-build-finish (buffer desc)
   "Callback function after compilation finishes."
-  (xcode-in-root (compile
-                  (format "ios-sim launch %s --devicetypeid '%s'"
-                          (xcode-completing-read
-                           "Select app: "
-                           (xcode-find-binaries) nil t)
-                          xcode-ios-sim-devicetype)))
+  (xcode-xctool-run)
   (remove-hook 'compilation-finish-functions 'xcode-on-build-finish))
-
 
 ;; Cleaning
 

--- a/xcode-mode.el
+++ b/xcode-mode.el
@@ -147,9 +147,12 @@
   (interactive)
   (xcode-in-root (compile
                   (format "ios-sim launch %s --devicetypeid '%s'"
-                          (xcode-completing-read
-                           "Select app: "
-                           (xcode-find-binaries) nil t)
+                          (let ((xcode-binaries (xcode-find-binaries)))
+                            (if (eq 1 (length xcode-binaries))
+                                (car xcode-binaries)
+                              (xcode-completing-read
+                               "Select app: "
+                               xcode-binaries nil t)))
                           xcode-ios-sim-devicetype))))
 
 (defun xcode-xctool-build-and-run ()


### PR DESCRIPTION
After building, if there's only one binary in derived data, it's very convenient to automatically select that one to run.
